### PR TITLE
Example Use of setting zindexbehavior for view on viewport

### DIFF
--- a/src/Reflex/StoryPreview/StoryMount.ts
+++ b/src/Reflex/StoryPreview/StoryMount.ts
@@ -22,6 +22,8 @@ declare global {
 		Order: number;
 
 		ActionComponents: Map<string, ActionTabEntry>;
+
+		ZIndexBehavior?: Enum.ZIndexBehavior;
 	}
 }
 const DefaultEntry = {
@@ -32,6 +34,7 @@ const DefaultEntry = {
 	OnWidget: false,
 	OnViewport: false,
 	AutoReload: true,
+	ZIndexBehavior: Enum.ZIndexBehavior.Sibling,
 } satisfies Partial<PreviewEntry>;
 
 interface StoryMountState {

--- a/src/UI/StoryOverlay/IconToolbar/index.tsx
+++ b/src/UI/StoryOverlay/IconToolbar/index.tsx
@@ -1,5 +1,5 @@
 import { lerp } from "@rbxts/pretty-react-hooks";
-import React, { useCallback, useEffect, useState } from "@rbxts/react";
+import React, { useCallback, useEffect } from "@rbxts/react";
 import { useToggler } from "Hooks/Utils/Toggler";
 import { useTween } from "Hooks/Utils/Tween";
 import { Detector } from "UI/Styles/Detector";
@@ -24,7 +24,7 @@ const HOVER_INFO = new TweenInfo(0.15, Enum.EasingStyle.Cubic, Enum.EasingDirect
 function IconToolbar(props: IconToolbarProps) {
 	const [hovered, hoverApi] = useToggler(false);
 	const [hoverAlpha, tweenHoverAlpha] = useTween(HOVER_INFO, 0);
-	const [zIndexBehavior, setZIndexBehavior] = useState("Sibling");
+	const [zIndexBehaviorGlobal, zIndexBehaviorGlobalApi] = useToggler(false);
 	const { updateMountData, setMountData } = useProducer<RootProducer>();
 	const count = Counter();
 
@@ -58,11 +58,6 @@ function IconToolbar(props: IconToolbarProps) {
 		updateMountData(entry.Key, (old) =>
 			Immut.produce(old, (draft) => {
 				draft.OnViewport = !draft.OnViewport;
-				if (zIndexBehavior === "Global") {
-					draft.ZIndexBehavior = Enum.ZIndexBehavior.Global;
-				} else {
-					draft.ZIndexBehavior = Enum.ZIndexBehavior.Sibling;
-				}
 			}),
 		);
 	}, [entry]);
@@ -75,12 +70,12 @@ function IconToolbar(props: IconToolbarProps) {
 	const toggleZIndexBehavior = useCallback(() => {
 		updateMountData(entry.Key, (old) =>
 			Immut.produce(old, (draft) => {
-				if (zIndexBehavior === "Global") {
+				if (zIndexBehaviorGlobal) {
 					draft.ZIndexBehavior = Enum.ZIndexBehavior.Sibling;
-					setZIndexBehavior("Sibling");
+					zIndexBehaviorGlobalApi.disable();
 				} else {
 					draft.ZIndexBehavior = Enum.ZIndexBehavior.Global;
-					setZIndexBehavior("Global");
+					zIndexBehaviorGlobalApi.enable();
 				}
 			}),
 		);

--- a/src/UI/StoryOverlay/IconToolbar/index.tsx
+++ b/src/UI/StoryOverlay/IconToolbar/index.tsx
@@ -23,7 +23,6 @@ const HOVER_INFO = new TweenInfo(0.15, Enum.EasingStyle.Cubic, Enum.EasingDirect
 function IconToolbar(props: IconToolbarProps) {
 	const [hovered, hoverApi] = useToggler(false);
 	const [hoverAlpha, tweenHoverAlpha] = useTween(HOVER_INFO, 0);
-	const [zIndexBehaviorGlobal, zIndexBehaviorGlobalApi] = useToggler(false);
 	const { updateMountData, setMountData } = useProducer<RootProducer>();
 	const count = Counter();
 
@@ -69,12 +68,10 @@ function IconToolbar(props: IconToolbarProps) {
 	const toggleZIndexBehavior = useCallback(() => {
 		updateMountData(entry.Key, (old) =>
 			Immut.produce(old, (draft) => {
-				if (zIndexBehaviorGlobal) {
+				if (old.ZIndexBehavior === Enum.ZIndexBehavior.Global) {
 					draft.ZIndexBehavior = Enum.ZIndexBehavior.Sibling;
-					zIndexBehaviorGlobalApi.disable();
 				} else {
 					draft.ZIndexBehavior = Enum.ZIndexBehavior.Global;
-					zIndexBehaviorGlobalApi.enable();
 				}
 			}),
 		);
@@ -123,7 +120,7 @@ function IconToolbar(props: IconToolbarProps) {
 					Order={count()}
 				/>
 				<SpriteButton
-					ButtonName="ViewportZIndexBehaviorT"
+					ButtonName="ViewportZIndexBehavior"
 					Sprite="Picker"
 					Active={entry.OnViewport}
 					Description="Toggle ZIndex Behavior To Global/Sibling"

--- a/src/UI/StoryOverlay/IconToolbar/index.tsx
+++ b/src/UI/StoryOverlay/IconToolbar/index.tsx
@@ -13,7 +13,6 @@ import { Counter } from "Utils/NumberUtils";
 import { useProducer } from "@rbxts/react-reflex";
 import Immut from "@rbxts/immut";
 import { Selection } from "@rbxts/services";
-import { set } from "@rbxts/sift/out/Array";
 
 interface IconToolbarProps {
 	PreviewEntry: PreviewEntry;

--- a/src/UI/StoryPreview/PreviewController/Holders/Preview/Viewport.tsx
+++ b/src/UI/StoryPreview/PreviewController/Holders/Preview/Viewport.tsx
@@ -19,7 +19,7 @@ function Viewport(props: StoryHolderProps) {
 	});
 
 	return createPortal(
-		<screengui key={storyName} ZIndexBehavior={Enum.ZIndexBehavior.Sibling}>
+		<screengui key={storyName} ZIndexBehavior={props.PreviewEntry.ZIndexBehavior}>
 			<Div key={"Holder"} Reference={mountRef}></Div>
 		</screengui>,
 		game.GetService("CoreGui"),


### PR DESCRIPTION
Example with toggled to global
![image](https://github.com/PepeElToro41/ui-labs/assets/85452235/107a9b0b-4806-4a6d-904e-71d80c1f30e3)


Example when toggled to sibling
![image](https://github.com/PepeElToro41/ui-labs/assets/85452235/9ef909e2-7117-4af5-b4d7-552e4d77b3cb)


Button on the toolbar
![image](https://github.com/PepeElToro41/ui-labs/assets/85452235/d4aa0d1e-6444-43b3-816f-c4d51cfc5157)

Purpose of this was to view certain components of the UI with global behaviour in the view on viewport
