### PR TITLE
Pin bottom pane by default (better UX)

### DIFF
--- a/src/Context/StoryPanelContext.tsx
+++ b/src/Context/StoryPanelContext.tsx
@@ -13,7 +13,7 @@ const StoryPanelContext = React.createContext({} as StoryPanelContext);
 interface StoryPanelProps extends PropsWithChildren {}
 
 export function StoryPanelProvider(props: StoryPanelProps) {
-	const [actionsPinned, setActionsPinned] = useState(false);
+	const [actionsPinned, setActionsPinned] = useState(true);
 	const [actionsHeight, setActionsHeight] = useBinding<number>(0);
 
 	const contextValue = useMemo(() => {

--- a/src/Context/ToolsContext.tsx
+++ b/src/Context/ToolsContext.tsx
@@ -18,7 +18,7 @@ const ToolsContext = React.createContext({} as ToolsContext);
 interface ToolsProps extends PropsWithChildren {}
 
 export function ToolsProvider(props: ToolsProps) {
-	const [toolbarPosition, setToolbarPosition] = useState<ToolbarPosition>("Floating");
+	const [toolbarPosition, setToolbarPosition] = useState<ToolbarPosition>("Anchored");
 
 	const [toolButtonsActive, setToolButtonsActive] = useState<ToolsButtonActive>(() => {
 		const active = {} as ToolsButtonActive;

--- a/src/Context/ToolsContext.tsx
+++ b/src/Context/ToolsContext.tsx
@@ -18,7 +18,7 @@ const ToolsContext = React.createContext({} as ToolsContext);
 interface ToolsProps extends PropsWithChildren {}
 
 export function ToolsProvider(props: ToolsProps) {
-	const [toolbarPosition, setToolbarPosition] = useState<ToolbarPosition>("Anchored");
+	const [toolbarPosition, setToolbarPosition] = useState<ToolbarPosition>("Floating");
 
 	const [toolButtonsActive, setToolButtonsActive] = useState<ToolsButtonActive>(() => {
 		const active = {} as ToolsButtonActive;


### PR DESCRIPTION
This alters the default context states for the bottom window such that it is pinned by default. 

See #44 for more details.

This closes #44.