### PR TITLE
Ensure all missing returns / exports are added for clarity

### DIFF
--- a/docs/docs/controls/adding.md
+++ b/docs/docs/controls/adding.md
@@ -30,6 +30,8 @@ local story = {
    controls = controls,
    story = ...
 }
+
+return story
 ```
 
 ```ts [Roblox-TS] {2-4,8}
@@ -43,6 +45,8 @@ const story = {
    controls: controls,
    story: ...
 }
+
+export = story;
 ```
 
 :::

--- a/docs/docs/controls/advanced.md
+++ b/docs/docs/controls/advanced.md
@@ -155,6 +155,8 @@ local story = {
    controls = controls,
    story = ...
 }
+
+return story
 ```
 
 :::

--- a/docs/docs/controls/primitive.md
+++ b/docs/docs/controls/primitive.md
@@ -35,6 +35,8 @@ local story = {
    controls = controls,
    story = ...
 }
+
+return story
 ```
 
 ```ts [Roblox-TS] {2-5}
@@ -49,6 +51,8 @@ const story = {
    controls: controls,
    story: ...
 }
+
+export = story;
 ```
 
 :::
@@ -156,6 +160,8 @@ local story = {
    controls = controls,
    story = ...
 }
+
+return story
 ```
 
 ```tsx [Roblox-TS]

--- a/docs/docs/stories/advanced/fusion.md
+++ b/docs/docs/stories/advanced/fusion.md
@@ -41,6 +41,8 @@ local story = {
       }
    end
 }
+
+return story
 ```
  
 ```tsx [Roblox-TS] {4-8}
@@ -53,6 +55,8 @@ const story = {
       })
    }
 }
+
+export = story;
 ```
 
 :::
@@ -79,6 +83,8 @@ local story = {
       }
    end
 }
+
+return story
 ```
  
 ```tsx [Roblox-TS] {12}
@@ -97,6 +103,8 @@ const story = {
       })
    }
 }
+
+export = story;
 ```
 
 :::
@@ -126,6 +134,8 @@ local story = {
       end
    end
 }
+
+return story
 ```
  
 ```tsx [Roblox-TS] {9-11}
@@ -142,6 +152,8 @@ const story = {
       }
    }
 }
+
+export = story;
 ```
 
 :::
@@ -179,6 +191,8 @@ local story = {
       -- cleanup function is not needed
    end,
 }
+
+return story
 ```
  
 ```tsx [Roblox-TS] {12-14}
@@ -218,6 +232,8 @@ local story = CreateFusionStory({
       component:Destroy()
    end
 end)
+
+return story
 ```
  
 ```tsx [Roblox-TS]
@@ -239,6 +255,7 @@ const story = CreateFusionStory({
    }
 })
 
+export = story;
 ```
 
 :::

--- a/docs/docs/stories/advanced/generic.md
+++ b/docs/docs/stories/advanced/generic.md
@@ -39,6 +39,8 @@ local story = {
       component.Parent = props.target
    end
 }
+
+return story
 ```
 
 ```tsx [Roblox-TS]
@@ -84,6 +86,8 @@ const story = {
       };
    },
 };
+
+export = story;
 ```
 
 :::
@@ -150,6 +154,8 @@ local story = {
       end
    end
 }
+
+return story
 ```
 
 ```tsx [Roblox-TS] {16-18}
@@ -178,6 +184,8 @@ const story = {
       };
 	},
 };
+
+export = story;
 ```
 
 :::
@@ -216,6 +224,8 @@ local story = {
       end
    end
 }
+
+return story
 ```
 
 ```tsx [Roblox-TS]
@@ -244,6 +254,8 @@ const story = {
       };
 	},
 };
+
+export = story;
 ```
 
 :::
@@ -302,6 +314,8 @@ local story = {
       end
    end
 }
+
+return story
 ```
 
 ```tsx [Roblox-TS]
@@ -323,6 +337,8 @@ const story = {
       }
    }
 }
+
+export = story;
 ```
 
 :::
@@ -481,6 +497,8 @@ local story = {
       end
    end
 }
+
+return story
 ```
 
 ```tsx [Roblox-TS]
@@ -509,6 +527,8 @@ const story = {
       }
    }
 }
+
+export = story;
 ```
 
 :::
@@ -579,6 +599,8 @@ local story = {
       end
    end
 }
+
+return story
 ```
 
 ```tsx [Roblox-TS]
@@ -612,6 +634,8 @@ const story = {
       };
 	},
 };
+
+export = story;
 ```
 
 :::
@@ -650,6 +674,8 @@ local story = {
       end
    end
 }
+
+return story
 ```
 
 ```tsx [Roblox-TS]
@@ -681,6 +707,8 @@ const story = {
       };
 	},
 };
+
+export = story;
 ```
 
 :::
@@ -726,6 +754,8 @@ local story = {
       end
    end
 }
+
+return story
 ```
 
 ```tsx [Roblox-TS]
@@ -773,6 +803,8 @@ const story = {
       };
 	},
 };
+
+export = story;
 ```
 
 :::
@@ -808,6 +840,8 @@ local story = CreateGenericStory({
       component:Destroy()
    end
 end)
+
+return story
 ```
 
 ```tsx [Roblox-TS]
@@ -828,4 +862,6 @@ const story = CreateGenericStory({
       component.Destroy();
    };
 });
+
+export = story;
 ```

--- a/docs/docs/stories/advanced/react.md
+++ b/docs/docs/stories/advanced/react.md
@@ -83,6 +83,8 @@ local story = {
       return component
    end
 }
+
+return story
 ```
  
 ```tsx [Roblox-TS]
@@ -95,6 +97,8 @@ const story = {
       return component
    }, 
 }
+
+export = story;
 ``` 
  
 :::
@@ -122,6 +126,8 @@ local story = {
       return component
    end
 }
+
+return story
 ```
  
 ```tsx [Roblox-TS] {7}
@@ -139,6 +145,8 @@ const story = {
       return component
    }
 }
+
+export = story;
 ```
 
 :::
@@ -166,6 +174,8 @@ local story = {
       return component
    end 
 }
+
+return story
 ```
  
 ```tsx [Roblox-TS]
@@ -183,6 +193,8 @@ const story = {
       return component
    },
 }
+
+export = story;
 ```
 :::
 
@@ -203,6 +215,8 @@ local story = {
       return component
    end 
 }
+
+return story
 ```
  
 ```tsx [Roblox-TS]
@@ -218,6 +232,8 @@ const story = {
       return component
    },
 }
+
+export = story;
 ```
 :::
 
@@ -253,6 +269,8 @@ local story = CreateReactStory({
    local component = React.createElement("Frame", {})
    return component
 end)
+
+return story
 ```
  
 ```tsx [Roblox-TS]
@@ -269,6 +287,8 @@ const story = CreateReactStory({
    const component = <frame />
    return component
 })
+
+export = story;
 ```
 
 :::
@@ -290,6 +310,8 @@ local story = CreateRoactStory({
    local component = Roact.createElement("Frame", {})
    return component
 end)
+
+return story
 ```
  
 ```tsx [Roblox-TS]
@@ -305,6 +327,7 @@ const story = CreateRoactStory({
    return component
 })
 
+export = story;
 ```
 
 :::

--- a/docs/docs/stories/create.md
+++ b/docs/docs/stories/create.md
@@ -8,20 +8,18 @@ Stories are `ModuleScript`s that ends with `.story` in their name. These modules
 
 ---
 
-</br>Story modules should return the story you want to render. We're gonna learn how stories are written in the next section.
+</br>Story modules should return the story you want to render. We will learn how stories are written in the next section.
 
 ::: code-group
 
 ```lua [Luau]
 local story = ...
-
 return story
 ```
 
 ```ts [Roblox-TS]
 const story = ...
-
-export = story
+export = story;
 ```
 
 :::

--- a/docs/docs/stories/function.md
+++ b/docs/docs/stories/function.md
@@ -42,6 +42,8 @@ function story(target: Frame)
       -- Clean up your story here
    end
 end
+
+return story
 ```
 
 ```ts [Roblox-TS] {4-6}
@@ -74,6 +76,8 @@ local function story(target)
       Roact.unmount(handle)
    end
 end
+
+return story
 ```
 
 :::


### PR DESCRIPTION
I noticed a few of the code examples in the UI labs documentation did not include a return / export for the story. This PR just ensures it's consistent across the board and all code examples that contain stories have a return or export.