### PR TITLE
Improve zooming functionality

### DIFF
--- a/src/Reflex/StoryPreview/index.ts
+++ b/src/Reflex/StoryPreview/index.ts
@@ -49,7 +49,7 @@ const initialState: StoryPreviewState = {
 	latestViewOnViewport: false
 };
 
-const MIN_ZOOM = 5;
+const MIN_ZOOM = 10;
 const MAX_ZOOM = 26000;
 
 export const selectStoryPreview = (state: RootState) => state.storyPreview;

--- a/src/Reflex/StoryPreview/index.ts
+++ b/src/Reflex/StoryPreview/index.ts
@@ -298,7 +298,7 @@ export const StoryPreviewProducer = createProducer(initialState, {
 	/**
 	 * Zooms by adding a delta.
 	 * A positive delta zooms in. (100 applies a +100% zoom)
-	 * Optionally, providing an offset of the cursor relative to the holder offset will ensure that the content at that location keeps its location on the screen.
+	 * Optionally, providing an offset of the cursor relative to the holder's anchor will ensure that the content at that location stays in place.
 	 */
 	addZoom: (state, key: string, zoomDelta: number, cursorOffset?: Vector2) => {
 		const current = GetEntryByKey(state.mountPreviews, key);

--- a/src/UI/StoryOverlay/CanvasControls/index.tsx
+++ b/src/UI/StoryOverlay/CanvasControls/index.tsx
@@ -50,7 +50,7 @@ function CanvasControls(props: CanvasControlsProps) {
 					}
 					addZoom(
 						props.PreviewEntry.Key,
-						input.Position.Z * 5,
+						input.Position.Z * 20,
 						cursorRelativeToAnchor
 					);
 				}

--- a/src/UI/StoryOverlay/CanvasControls/index.tsx
+++ b/src/UI/StoryOverlay/CanvasControls/index.tsx
@@ -1,6 +1,11 @@
 import Immut from "@rbxts/immut";
 import { useEventListener } from "@rbxts/pretty-react-hooks";
-import React, { useBinding, useCallback, useEffect, useState } from "@rbxts/react";
+import React, {
+	useBinding,
+	useCallback,
+	useEffect,
+	useState
+} from "@rbxts/react";
 import { useProducer } from "@rbxts/react-reflex";
 import { RunService } from "@rbxts/services";
 import { useInputBegan, useInputEnded } from "Hooks/Context/UserInput";
@@ -29,11 +34,29 @@ function CanvasControls(props: CanvasControlsProps) {
 			if (input.UserInputType === Enum.UserInputType.MouseMovement) {
 				setMousePos(new Vector2(input.Position.X, input.Position.Y));
 			} else if (input.UserInputType === Enum.UserInputType.MouseWheel) {
-				if (!shiftClicked) return;
-				addZoom(props.PreviewEntry.Key, input.Position.Z * 5);
+				if (ctrlClicked || shiftClicked) {
+					let cursorRelativeToAnchor: Vector2 | undefined;
+					// Ctrl-Zoom zooms towards the cursor
+					// Shift-Zoom simply zooms
+					if (ctrlClicked) {
+						const holder = props.PreviewEntry.Holder;
+						if (holder) {
+							const holderAnchorPos = holder.AbsolutePosition.add(
+								holder.AbsoluteSize.mul(holder.AnchorPoint)
+							);
+							const currentPos = mousePos.getValue();
+							cursorRelativeToAnchor = currentPos.sub(holderAnchorPos);
+						}
+					}
+					addZoom(
+						props.PreviewEntry.Key,
+						input.Position.Z * 5,
+						cursorRelativeToAnchor
+					);
+				}
 			}
 		},
-		[shiftClicked],
+		[ctrlClicked, shiftClicked]
 	);
 	const OnInputBegan = useCallback((_: Frame, input: InputObject) => {
 		if (input.UserInputType === Enum.UserInputType.MouseButton3) {
@@ -81,7 +104,7 @@ function CanvasControls(props: CanvasControlsProps) {
 			updateMountData(props.PreviewEntry.Key, (old) =>
 				Immut.produce(old, (draft) => {
 					draft.Offset = old.Offset.add(delta);
-				}),
+				})
 			);
 		});
 
@@ -94,7 +117,7 @@ function CanvasControls(props: CanvasControlsProps) {
 				InputBegan: OnInputBegan,
 				InputChanged: OnInputChanged,
 				MouseEnter: insideApi.enable,
-				MouseLeave: insideApi.disable,
+				MouseLeave: insideApi.disable
 			}}
 		></Div>
 	);

--- a/src/UI/StoryOverlay/CanvasControls/index.tsx
+++ b/src/UI/StoryOverlay/CanvasControls/index.tsx
@@ -1,14 +1,13 @@
 import Immut from "@rbxts/immut";
 import { useEventListener } from "@rbxts/pretty-react-hooks";
-import React, {
-	useBinding,
-	useCallback,
-	useEffect,
-	useState
-} from "@rbxts/react";
+import React, { useCallback, useEffect, useState } from "@rbxts/react";
 import { useProducer } from "@rbxts/react-reflex";
 import { RunService } from "@rbxts/services";
-import { useInputBegan, useInputEnded } from "Hooks/Context/UserInput";
+import {
+	useInputBegan,
+	useInputEnded,
+	useMousePos
+} from "Hooks/Context/UserInput";
 import { useToggler } from "Hooks/Utils/Toggler";
 import { Div } from "UI/Styles/Div";
 
@@ -17,7 +16,7 @@ interface CanvasControlsProps {
 }
 
 function CanvasControls(props: CanvasControlsProps) {
-	const [mousePos, setMousePos] = useBinding<Vector2>(new Vector2());
+	const mousePos = useMousePos();
 	const [inside, insideApi] = useToggler(false);
 	const [middleClicked, setMiddleClicked] = useState(false);
 	const [leftClicked, setLeftClicked] = useState(false);
@@ -31,9 +30,7 @@ function CanvasControls(props: CanvasControlsProps) {
 
 	const OnInputChanged = useCallback(
 		(_: Frame, input: InputObject) => {
-			if (input.UserInputType === Enum.UserInputType.MouseMovement) {
-				setMousePos(new Vector2(input.Position.X, input.Position.Y));
-			} else if (input.UserInputType === Enum.UserInputType.MouseWheel) {
+			if (input.UserInputType === Enum.UserInputType.MouseWheel) {
 				if (ctrlClicked || shiftClicked) {
 					let cursorRelativeToAnchor: Vector2 | undefined;
 					// Ctrl-Zoom zooms towards the cursor

--- a/src/UI/StoryOverlay/IconToolbar/Buttons.tsx/ZoomIn.tsx
+++ b/src/UI/StoryOverlay/IconToolbar/Buttons.tsx/ZoomIn.tsx
@@ -21,6 +21,7 @@ function ZoomIn(props: ToolButtonProps) {
 			OnRightClick={props.OnRightClick}
 			Order={props.Order}
 			Shortcut={Enum.KeyCode.Equals}
+			ShortcutModifier={Enum.ModifierKey.Ctrl}
 		/>
 	);
 }

--- a/src/UI/StoryOverlay/IconToolbar/Buttons.tsx/ZoomOut.tsx
+++ b/src/UI/StoryOverlay/IconToolbar/Buttons.tsx/ZoomOut.tsx
@@ -20,6 +20,7 @@ function ZoomOut(props: ToolButtonProps) {
 			OnRightClick={props.OnRightClick}
 			Order={props.Order}
 			Shortcut={Enum.KeyCode.Minus}
+			ShortcutModifier={Enum.ModifierKey.Ctrl}
 		/>
 	);
 }

--- a/src/UI/StoryOverlay/ToastInfo/index.tsx
+++ b/src/UI/StoryOverlay/ToastInfo/index.tsx
@@ -22,14 +22,14 @@ function ToastInfo(setprops: ToastInfoProps) {
 	useDebounceEffect(() => setToastRender(undefined), [toastRender], { wait: 0.6 });
 	useUpdateEffect(() => {
 		const renderMap: ReactChildren = new Map();
-		renderMap.set("ZoomDisplay", <ToastInfoRender InfoText={`Zoom: ${entry.Zoom}%`} />);
-		setToastRender(renderMap);
-	}, [entry.Zoom]);
-	useUpdateEffect(() => {
-		const renderMap: ReactChildren = new Map();
-		renderMap.set("OffsetDisplay", <ToastInfoRender InfoText={`Offset: [${entry.Offset}]`} />);
+		renderMap.set("OffsetDisplay", <ToastInfoRender InfoText={`Offset: [${math.round(entry.Offset.X)}, ${math.round(entry.Offset.Y)}]`} />);
 		setToastRender(renderMap);
 	}, [entry.Offset]);
+	useUpdateEffect(() => {
+		const renderMap: ReactChildren = new Map();
+		renderMap.set("ZoomDisplay", <ToastInfoRender InfoText={`Zoom: ${math.round(entry.Zoom)}%`} />);
+		setToastRender(renderMap);
+	}, [entry.Zoom]);
 	useUpdateEffect(() => {
 		const renderMap: ReactChildren = new Map();
 		renderMap.set("FullscreenMode", <ToastInfoRender InfoText={`Fullscreen Mode: ${fullscreen ? "On" : "Off"}`} />);


### PR DESCRIPTION
this PR adds the ability to ctrl-zoom to zoom towards the cursor
it also changes zoom shortcuts + and - to be more in line with other programs by requiring ctrl to be held, and increases the sentitivity of scrolling which felt like a snail

i can change anything you don't particularly like, but honestly i would also suggest moving from a zoom delta to a zoom multiplier instead. i can implement that if you'd like

because with a delta, adding +10% every time is less and less potent because the change from 100% to 110% is a particularly noticeable one (a 10% difference), but moving from 300% to 310% becomes less and less noticeable (a 3% difference), whereas if we multiplied the current zoom by 15% or so everytime, each change in zoom would be the same as the last one. rounding errors are a bit of a problem but it's not impossible to solve.

Closes #41 