### PR TITLE
Fix: Update GitHub button link to point to correct repository

### DIFF
--- a/docs/.vitepress/config/shared.ts
+++ b/docs/.vitepress/config/shared.ts
@@ -30,6 +30,6 @@ export const shared = defineConfig({
 
 	themeConfig: {
 		logo: "/home/pluginicon.ico",
-		socialLinks: [{ icon: "github", link: "https://ui-labs.luau.page" }]
+		socialLinks: [{ icon: "github", link: "https://github.com/PepeElToro41/ui-labs" }]
 	}
 });


### PR DESCRIPTION
This PR updates the GitHub button link from: https://ui-labs.luau.page/ to https://github.com/PepeElToro41/ui-labs and ensures users are directed to the correct link.