### PR TITLE
Use ScriptEditorService for getting script sources

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
 				"patch-package": "^8.0.0",
 				"postinstall-postinstall": "^2.1.0",
 				"roblox-ts": "^3.0.0",
-				"typescript": "4.9.4"
+				"typescript": "^5.9.2"
 			}
 		},
 		"node_modules/@eslint-community/eslint-utils": {
@@ -2525,19 +2525,6 @@
 			"dev": true,
 			"license": "0BSD"
 		},
-		"node_modules/tsutils/node_modules/typescript": {
-			"version": "4.9.5",
-			"dev": true,
-			"license": "Apache-2.0",
-			"peer": true,
-			"bin": {
-				"tsc": "bin/tsc",
-				"tsserver": "bin/tsserver"
-			},
-			"engines": {
-				"node": ">=4.2.0"
-			}
-		},
 		"node_modules/type-check": {
 			"version": "0.4.0",
 			"dev": true,
@@ -2561,7 +2548,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.9.4",
+			"version": "5.9.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+			"integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -2569,7 +2558,7 @@
 				"tsserver": "bin/tsserver"
 			},
 			"engines": {
-				"node": ">=4.2.0"
+				"node": ">=14.17"
 			}
 		},
 		"node_modules/universalify": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"patch-package": "^8.0.0",
 		"postinstall-postinstall": "^2.1.0",
 		"roblox-ts": "^3.0.0",
-		"typescript": "4.9.4"
+		"typescript": "^5.9.2"
 	},
 	"dependencies": {
 		"@rbxts/catppuccin": "^1.0.2",

--- a/src/Actions/StoryLoading/Utils.ts
+++ b/src/Actions/StoryLoading/Utils.ts
@@ -1,3 +1,4 @@
+import { ScriptEditorService } from "@rbxts/services";
 import type { Environment } from "./Environment";
 
 /**
@@ -6,20 +7,24 @@ import type { Environment } from "./Environment";
  * @param module module that was loaded with loadstring()
  * @param environment Environment handler object
  */
-export function SetEnvironment(virtualModule: Callback, module: ModuleScript, environment: Environment) {
+export function SetEnvironment(
+	virtualModule: Callback,
+	module: ModuleScript,
+	environment: Environment
+) {
 	const globals = {
 		require: (dependency: ModuleScript) => {
 			return environment.LoadDependency(dependency).expect();
 		},
 		script: module,
-		_G: environment.Shared,
+		_G: environment.Shared
 	};
 	const env = getfenv();
 	const injection = environment.GetGlobalInjection();
 	const index = injection ? setmetatable(injection, { __index: env }) : env;
 
 	const newEnvironment = setmetatable(globals, {
-		__index: index, //defaults any global variables to the current global environment
+		__index: index //defaults any global variables to the current global environment
 	});
 	setfenv(virtualModule, newEnvironment);
 }
@@ -29,8 +34,14 @@ export function SetEnvironment(virtualModule: Callback, module: ModuleScript, en
  * @param module the module to laod
  * @param environment Environment handler object
  */
-export async function LoadVirtualModule(module: ModuleScript, environment: Environment) {
-	const [virtualModule, err] = loadstring(module.Source, module.GetFullName());
+export async function LoadVirtualModule(
+	module: ModuleScript,
+	environment: Environment
+) {
+	const [virtualModule, err] = loadstring(
+		ScriptEditorService.GetEditorSource(module),
+		module.GetFullName()
+	);
 
 	if (virtualModule === undefined) {
 		throw err;

--- a/src/Utils/HotReloader/Utils.ts
+++ b/src/Utils/HotReloader/Utils.ts
@@ -1,3 +1,4 @@
+import { ScriptEditorService } from "@rbxts/services";
 import type { Environment } from "./Environment";
 
 /**
@@ -62,7 +63,10 @@ export async function LoadVirtualModule(
 	module: ModuleScript,
 	environment: Environment
 ) {
-	const [virtualModule, err] = loadstring(module.Source, module.GetFullName());
+	const [virtualModule, err] = loadstring(
+		ScriptEditorService.GetEditorSource(module),
+		module.GetFullName()
+	);
 
 	if (virtualModule === undefined) {
 		throw err;


### PR DESCRIPTION
ScriptEditorService:GetEditorSource is the preferred method for getting a script's source
Roblox doesn't have an event for whenever a script source (in drafts mode, editor source) updates yet.

Drafts mode users can now hit the reload button if they want to update their story without committing.

TypeScript upgrade was needed to support compilerOptions.types, it errored previously.