### PR TITLE
Support package stories using the consumer game RuntimeLib

### DIFF
--- a/src/Utils/HotReloader/Utils.ts
+++ b/src/Utils/HotReloader/Utils.ts
@@ -1,6 +1,9 @@
-import { ScriptEditorService } from "@rbxts/services";
+import { ReplicatedStorage, ScriptEditorService } from "@rbxts/services";
 
 import type { Environment } from "./Environment";
+
+let gameRuntimeTS: ModuleScript | undefined;
+let runtimeLibModule: ModuleScript | undefined;
 
 /**
  * Replaces the environment of a loadstring'ed function
@@ -35,6 +38,10 @@ export function SetEnvironment(virtualModule: Callback, module: ModuleScript, en
 			if (resolved === undefined) {
 				error(`Could not resolve require ${dependency} in ${module}`, 2);
 			}
+			
+			if (runtimeLibModule !== undefined && resolved === runtimeLibModule) {
+				return gameRuntimeTS;
+			}
 
 			return environment.LoadDependency(resolved).expect();
 		},
@@ -51,6 +58,19 @@ export function SetEnvironment(virtualModule: Callback, module: ModuleScript, en
 	setfenv(virtualModule, newEnvironment);
 }
 
+export function InjectRbxtsRuntime(module: ModuleScript, environment: Environment) {
+	const rbxtsInclude = ReplicatedStorage.FindFirstChild("rbxts_include") as Folder | undefined;
+	if (rbxtsInclude === undefined) return;
+
+	runtimeLibModule = rbxtsInclude.FindFirstChild("RuntimeLib") as ModuleScript | undefined;
+	if (runtimeLibModule === undefined) return;
+
+	gameRuntimeTS = require(runtimeLibModule) as ModuleScript;
+
+	// Give the story the game's TS runtime
+	(environment.Shared as Record<never, unknown>)[module as never] = gameRuntimeTS as never;
+}
+
 /**
  * Requires a module by using loadstring, this also replaces the _G table and the function "require()"
  * @param module the module to laod
@@ -64,6 +84,7 @@ export async function LoadVirtualModule(module: ModuleScript, environment: Envir
 	}
 
 	SetEnvironment(virtualModule, module, environment);
+	InjectRbxtsRuntime(module, environment);
 
 	const [sucess, result] = pcall(virtualModule);
 	if (sucess) {

--- a/src/Utils/HotReloader/Utils.ts
+++ b/src/Utils/HotReloader/Utils.ts
@@ -2,8 +2,61 @@ import { ReplicatedStorage, ScriptEditorService } from "@rbxts/services";
 
 import type { Environment } from "./Environment";
 
-let gameRuntimeTS: ModuleScript | undefined;
 let runtimeLibModule: ModuleScript | undefined;
+
+interface RbxtsRuntime extends Record<string, unknown> {
+	import: (context: ModuleScript, module: Instance, ...path: string[]) => unknown;
+}
+
+function ResolveImport(module: Instance, path: string[]) {
+	let resolved = module;
+	for (const segment of path) {
+		resolved = resolved.WaitForChild(segment);
+	}
+
+	if (!resolved.IsA("ModuleScript")) {
+		error(`Failed to import! Expected ModuleScript, got ${resolved.ClassName}`, 2);
+	}
+
+	return resolved;
+}
+
+function FindPackageRoot(instance: Instance) {
+	let current = instance;
+	while (current.Parent !== undefined) {
+		const parent = current.Parent;
+		if (parent.Name === "node_modules" || parent.Parent?.Name === "node_modules") {
+			return current;
+		}
+		current = parent;
+	}
+}
+
+function ShouldUseGameRuntime(context: ModuleScript, module: ModuleScript) {
+	const packageRoot = FindPackageRoot(module);
+	return packageRoot !== undefined && packageRoot !== FindPackageRoot(context);
+}
+
+function GetEnvironmentRuntime(environment: Environment): RbxtsRuntime | undefined {
+	if (runtimeLibModule === undefined) return;
+	return (environment.Shared as Record<never, unknown>)[runtimeLibModule as never] as RbxtsRuntime | undefined;
+}
+
+function CreateEnvironmentRuntime(gameRuntime: RbxtsRuntime, environment: Environment): RbxtsRuntime {
+	return setmetatable(
+		{
+			import: (context: ModuleScript, module: Instance, ...path: string[]) => {
+				const dependency = ResolveImport(module, path);
+				if (ShouldUseGameRuntime(context, dependency)) {
+					return gameRuntime.import(context, dependency);
+				}
+
+				return environment.LoadDependency(dependency).expect();
+			}
+		},
+		{ __index: gameRuntime }
+	) as RbxtsRuntime;
+}
 
 /**
  * Replaces the environment of a loadstring'ed function
@@ -38,9 +91,9 @@ export function SetEnvironment(virtualModule: Callback, module: ModuleScript, en
 			if (resolved === undefined) {
 				error(`Could not resolve require ${dependency} in ${module}`, 2);
 			}
-			
+
 			if (runtimeLibModule !== undefined && resolved === runtimeLibModule) {
-				return gameRuntimeTS;
+				return GetEnvironmentRuntime(environment);
 			}
 
 			return environment.LoadDependency(resolved).expect();
@@ -65,10 +118,15 @@ export function InjectRbxtsRuntime(module: ModuleScript, environment: Environmen
 	runtimeLibModule = rbxtsInclude.FindFirstChild("RuntimeLib") as ModuleScript | undefined;
 	if (runtimeLibModule === undefined) return;
 
-	gameRuntimeTS = require(runtimeLibModule) as ModuleScript;
+	const gameRuntime = require(runtimeLibModule) as RbxtsRuntime;
+	let environmentRuntime = GetEnvironmentRuntime(environment);
+	if (environmentRuntime === undefined) {
+		environmentRuntime = CreateEnvironmentRuntime(gameRuntime, environment);
+		(environment.Shared as Record<never, unknown>)[runtimeLibModule as never] = environmentRuntime as never;
+	}
 
 	// Give the story the game's TS runtime
-	(environment.Shared as Record<never, unknown>)[module as never] = gameRuntimeTS as never;
+	(environment.Shared as Record<never, unknown>)[module as never] = environmentRuntime as never;
 }
 
 /**


### PR DESCRIPTION
## Why

As explained in #79, packages do not include their own RuntimeLib. Because of that, roblox-ts package output gets it from:

```lua
local TS = _G[script]
```

UI Labs runs stories in its own reload environment, where this value was not being set. The result was an `attempt to index nil with 'import'` error.

The fix uses the RuntimeLib already provided by the game at `ReplicatedStorage/rbxts_include/RuntimeLib` and injects it into the story environment. This also means custom RuntimeLib implementations and monorepo module resolution keep working as configured by the game.

## Keeping hot reload working

Using the game RuntimeLib directly introduced another problem: its `TS.import()` uses Roblox's normal `require()`, so imported project modules stayed cached. Both automatic and manual reload could keep showing old stories until Studio was restarted.

To avoid that, UI Labs now creates a small adapter around the game RuntimeLib for each reload environment:

- Imports from the story's own package or place source go through UI Labs' dependency loader.
- Imports from other `node_modules` packages continue using the game RuntimeLib.
- Other runtime functions, including `getModule()`, still come from the game RuntimeLib.