### PR TITLE
fix search matching for special characters

### DIFF
--- a/src/UI/SidePanel/StoryTree/SearchFilter.ts
+++ b/src/UI/SidePanel/StoryTree/SearchFilter.ts
@@ -33,7 +33,7 @@ export function FilterChildren(children: ChildrenNode[], filter: string) {
 				Children: filteredChildren
 			});
 		} else {
-			const match = child.Name.lower().match(filter.lower())[0];
+			const match = child.Name.lower().find(filter.lower(), 1, true)[0];
 			if (match === undefined) return;
 			filtered.push(child);
 		}


### PR DESCRIPTION
Treats search queries as literal substrings so characters such as hyphens do not invoke Luau pattern matching.